### PR TITLE
Support errors in Result

### DIFF
--- a/worker/result.go
+++ b/worker/result.go
@@ -1,0 +1,64 @@
+package worker
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+type Result struct {
+	JobID         string         `json:"jobId"`
+	WorkerID      string         `json:"workerId"`
+	Tags          []string       `json:"tags"`
+	Hostname      string         `json:"hostname"`
+	Command       string         `json:"command"`
+	Args          []string       `json:"args"`
+	Kwargs        map[string]any `json:"kwargs"`
+	Success       bool           `json:"success"`
+	Error         error          `json:"error"`
+	Return        any            `json:"return"`
+	Timestamp     time.Time      `json:"timestamp"`
+	ExecutionTime int64          `json:"executionTime"`
+}
+
+// Use a custom marshal to support *string errors
+func (r Result) MarshalJSON() ([]byte, error) {
+	type res Result
+
+	return json.Marshal(&struct{
+		res
+		Error *string `json:"error"`
+	}{
+		res: res(r),
+		Error: func() *string {
+			if r.Error == nil {
+				return nil
+			}
+
+			err := r.Error.Error()
+			return &err
+		}(),
+	})
+}
+
+func (r *Result) UnmarshalJSON(input []byte) error {
+	type res Result
+
+	tmp := &struct{
+		res
+		Error *string `json:"error"`
+	}{
+		res: res(*r),
+	}
+
+	if err := json.Unmarshal(input, &tmp); err != nil {
+		return err
+	}
+
+	*r = Result(tmp.res)
+	if tmp.Error != nil {
+		r.Error = errors.New(*tmp.Error)
+	}
+
+	return nil
+}

--- a/worker/result_test.go
+++ b/worker/result_test.go
@@ -1,0 +1,60 @@
+package worker
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestResultMarshalJSON(t *testing.T) {
+	cases := []struct{
+		Recv Result
+		Exp  string
+	}{
+		{Recv: Result{}, Exp: `"error":null`},
+		{Recv: Result{Error: errors.New("test")}, Exp: `"error":"test"`},
+	}
+
+	for _, c := range cases {
+		bytes, err := json.Marshal(c.Recv)
+		if err != nil {
+			t.Fatalf("failed to serialize Result: %v", err)
+		}
+
+		if !strings.Contains(string(bytes), c.Exp) {
+			t.Errorf("expected result to contain '%s', but didn't find it: %s", c.Exp, string(bytes))
+		}
+	}
+}
+
+func TestResultUnmarshalJSON(t *testing.T) {
+	errStr := "test"
+
+	cases := []struct{
+		Recv []byte
+		Exp  *string
+	}{
+		{Recv: []byte(`{"error":null}`), Exp: nil},
+		{Recv: []byte(`{"error":"test"}`), Exp: &errStr},
+	}
+
+	for _, c := range cases {
+		var res Result
+		if err := json.Unmarshal(c.Recv, &res); err != nil {
+			t.Fatalf("failed to deserialize Result: %v", err)
+		}
+
+		if res.Error == nil && c.Exp != nil {
+			t.Errorf("expected to find an error, but didn't")
+		}
+
+		if res.Error != nil && c.Exp == nil {
+			t.Errorf("expected no errors, but found an error")
+		}
+
+		if res.Error != nil && c.Exp != nil && res.Error.Error() != *c.Exp {
+			t.Errorf("the received error did not match the expected error")
+		}
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -57,26 +57,11 @@ type (
 	}
 )
 
-type (
-	Task struct {
-		Command string         `json:"command"`
-		Args    []string       `json:"args"`
-		Kwargs  map[string]any `json:"kwargs"`
-	}
-	Result struct {
-		JobID         string         `json:"jobId"`
-		WorkerID      string         `json:"workerId"`
-		Tags          []string       `json:"tags"`
-		Hostname      string         `json:"hostname"`
-		Command       string         `json:"command"`
-		Args          []string       `json:"args"`
-		Kwargs        map[string]any `json:"kwargs"`
-		Success       bool           `json:"success"`
-		Return        any            `json:"return"`
-		Timestamp     time.Time      `json:"timestamp"`
-		ExecutionTime int64          `json:"executionTime"`
-	}
-)
+type Task struct {
+	Command string         `json:"command"`
+	Args    []string       `json:"args"`
+	Kwargs  map[string]any `json:"kwargs"`
+}
 
 type (
 	StateRepository interface {


### PR DESCRIPTION
After messing around with having an error field in Result for a while, this is what I found to be the most ergonomically suitable for consumers I guess.

This PR will mean that to include errors, you can include them as normal errors:

```golang
worker.Result{
    Error: fmt.Errorf("something went sideways: %w", err)
}
```

And the custom MarshalJSON will make sure it's basically converted to a `*string` field meaning no error = null in JSON.

Take a look and see what you think, or if we should reconsider another option.