### PR TITLE
QOL: give default jobs a name to give a better overview when listing jobs

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -121,6 +121,7 @@ func New(ctx context.Context, opts ...Option) (*Worker, error) {
 	if _, err = worker.sc.NewJob(
 		gocron.DurationJob(10*time.Second),
 		gocron.NewTask(worker.garbageCollector),
+		gocron.WithName("garbage collector"),
 		gocron.WithContext(ctx),
 	); err != nil {
 		return worker, err
@@ -188,6 +189,7 @@ func (w *Worker) AddWorkload(ctx context.Context, wl Workload) (map[string]any, 
 	job, err := w.sc.NewJob(
 		gocron.DurationRandomJob(w.config.splayLo, w.config.splayHi),
 		gocron.NewTask(w.stateCheck(wl.Name())),
+		gocron.WithName(fmt.Sprintf("worker state check: %s", wl.Name())),
 		gocron.WithContext(ctx),
 	)
 	if err != nil {


### PR DESCRIPTION
Refines the task list of the worker when requesting a list of tasks in the scheduler.

Previously:
```json
{
    "id":"91f4bc18-1215-4bad-b59e-2ea6063991bc",
    "name":"github.com/Telenor-NMS-SE/ottomato/worker.(*Worker).garbageCollector-fm",
    "lastRun":"2025-06-04 17:00:07.836789 +0000 UTC",
    "nextRun":"2025-06-04 17:00:17.835963 +0000 UTC"
}
```

Will now be:
```json
{
    "id":"91f4bc18-1215-4bad-b59e-2ea6063991bc",
    "name":"garbage collector",
    "lastRun":"2025-06-04 17:00:07.836789 +0000 UTC",
    "nextRun":"2025-06-04 17:00:17.835963 +0000 UTC"
}
```