### PR TITLE
Create a context with timeout when running a statecheck to avoid stal…

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -288,6 +288,9 @@ func (w *Worker) GetWorkerID() string {
 // Checks current state on a workload
 func (w *Worker) stateCheck(host string) func(context.Context) {
 	return func(ctx context.Context) {
+		ctx, cancel := context.WithTimeout(ctx, w.config.pingTimeout)
+		defer cancel()
+
 		wl, exists := w.workloads[host]
 		if !exists {
 			return


### PR DESCRIPTION
Fixes an issue where `stateCheck` jobs can hang forever, binding up the worker indefinitely.